### PR TITLE
Ecommerce Event Tracking

### DIFF
--- a/link_noibu/cartridges/int_noibu/cartridge/client/default/js/noibu.js
+++ b/link_noibu/cartridges/int_noibu/cartridge/client/default/js/noibu.js
@@ -28,4 +28,32 @@ async function checkSDKExistanceAndAddCustomAttribute() {
     }
 }
 
+async function monitorEcommerceEvents() {
+    localStorage.setItem('n_platform', '1'); // disable funnel step ecomm events
+
+    await new Promise(resolve => document.addEventListener("DOMContentLoaded", resolve));
+
+    if (typeof $ === "undefined") return;
+
+    $("body").on("product:afterAddToCart", (event, data) => {
+        const payload = data?.noibu_product_added_to_cart || null;
+        track("product_added_to_cart", payload);
+    });
+
+    $("body").on("cart:update", (event, data) => {
+        const payload = data?.noibu_product_removed_from_cart || null;
+        track("product_removed_from_cart", payload);
+    });
+}
+
+async function track(eventName, eventData) {
+    if (!window.NOIBUJS) {
+        await new Promise(resolve => window.addEventListener("noibuSDKReady", resolve));
+    }
+
+    const result = NOIBUJS.track(eventName, eventData);
+    console.log('NOIBUJS track:', eventName, result, eventData);
+}
+
 checkSDKExistanceAndAddCustomAttribute();
+monitorEcommerceEvents();

--- a/link_noibu/cartridges/int_noibu/cartridge/client/default/js/noibu.js
+++ b/link_noibu/cartridges/int_noibu/cartridge/client/default/js/noibu.js
@@ -35,14 +35,26 @@ async function monitorEcommerceEvents() {
 
     if (typeof $ === "undefined") return;
 
-    $("body").on("product:afterAddToCart", (event, data) => {
-        const payload = data?.noibu_product_added_to_cart || null;
-        track("product_added_to_cart", payload);
-    });
+    $(document).ajaxComplete((_event, xhr) => {
+        let data;
+        try { data = JSON.parse(xhr.responseText); } catch { return; }
 
-    $("body").on("cart:update", (event, data) => {
-        const payload = data?.noibu_product_removed_from_cart || null;
-        track("product_removed_from_cart", payload);
+        if (data.noibu_product_added_to_cart) {
+            track("product_added_to_cart", data.noibu_product_added_to_cart);
+        }
+        if (data.noibu_product_removed_from_cart) {
+            track("product_removed_from_cart", data.noibu_product_removed_from_cart);
+        }
+        if (data.noibu_checkout_contact_info_submitted) {
+            track("checkout_contact_info_submitted", data.noibu_checkout_contact_info_submitted);
+        }
+        if (data.noibu_checkout_address_info_submitted) {
+            track("checkout_address_info_submitted", data.noibu_checkout_address_info_submitted);
+            track("checkout_shipping_info_submitted", data.noibu_checkout_shipping_info_submitted);
+        }
+        if (data.noibu_payment_info_submitted) {
+            track("payment_info_submitted", data.noibu_payment_info_submitted);
+        }
     });
 }
 

--- a/link_noibu/cartridges/int_noibu/cartridge/client/default/js/noibu.js
+++ b/link_noibu/cartridges/int_noibu/cartridge/client/default/js/noibu.js
@@ -64,7 +64,6 @@ async function track(eventName, eventData) {
     }
 
     const result = NOIBUJS.track(eventName, eventData);
-    console.log('NOIBUJS track:', eventName, result, eventData);
 }
 
 checkSDKExistanceAndAddCustomAttribute();

--- a/link_noibu/cartridges/int_noibu/cartridge/static/default/js/noibu.js
+++ b/link_noibu/cartridges/int_noibu/cartridge/static/default/js/noibu.js
@@ -30,7 +30,35 @@ async function checkSDKExistanceAndAddCustomAttribute() {
     }
 }
 
+async function monitorEcommerceEvents() {
+    localStorage.setItem('n_platform', '1'); // disable funnel step ecomm events
+
+    await new Promise(resolve => document.addEventListener("DOMContentLoaded", resolve));
+
+    if (typeof $ === "undefined") return;
+
+    $("body").on("product:afterAddToCart", (event, data) => {
+        const payload = data?.noibu_product_added_to_cart || null;
+        track("product_added_to_cart", payload);
+    });
+
+    $("body").on("cart:update", (event, data) => {
+        const payload = data?.noibu_product_removed_from_cart || null;
+        track("product_removed_from_cart", payload);
+    });
+}
+
+async function track(eventName, eventData) {
+    if (!window.NOIBUJS) {
+        await new Promise(resolve => window.addEventListener("noibuSDKReady", resolve));
+    }
+
+    const result = NOIBUJS.track(eventName, eventData);
+    console.log('NOIBUJS track:', eventName, result, eventData);
+}
+
 checkSDKExistanceAndAddCustomAttribute();
+monitorEcommerceEvents();
 
 /******/ })()
 ;

--- a/link_noibu/cartridges/int_noibu/cartridge/static/default/js/noibu.js
+++ b/link_noibu/cartridges/int_noibu/cartridge/static/default/js/noibu.js
@@ -66,7 +66,6 @@ async function track(eventName, eventData) {
     }
 
     const result = NOIBUJS.track(eventName, eventData);
-    console.log('NOIBUJS track:', eventName, result, eventData);
 }
 
 checkSDKExistanceAndAddCustomAttribute();

--- a/link_noibu/cartridges/int_noibu/cartridge/static/default/js/noibu.js
+++ b/link_noibu/cartridges/int_noibu/cartridge/static/default/js/noibu.js
@@ -37,14 +37,26 @@ async function monitorEcommerceEvents() {
 
     if (typeof $ === "undefined") return;
 
-    $("body").on("product:afterAddToCart", (event, data) => {
-        const payload = data?.noibu_product_added_to_cart || null;
-        track("product_added_to_cart", payload);
-    });
+    $(document).ajaxComplete((_event, xhr) => {
+        let data;
+        try { data = JSON.parse(xhr.responseText); } catch { return; }
 
-    $("body").on("cart:update", (event, data) => {
-        const payload = data?.noibu_product_removed_from_cart || null;
-        track("product_removed_from_cart", payload);
+        if (data.noibu_product_added_to_cart) {
+            track("product_added_to_cart", data.noibu_product_added_to_cart);
+        }
+        if (data.noibu_product_removed_from_cart) {
+            track("product_removed_from_cart", data.noibu_product_removed_from_cart);
+        }
+        if (data.noibu_checkout_contact_info_submitted) {
+            track("checkout_contact_info_submitted", data.noibu_checkout_contact_info_submitted);
+        }
+        if (data.noibu_checkout_address_info_submitted) {
+            track("checkout_address_info_submitted", data.noibu_checkout_address_info_submitted);
+            track("checkout_shipping_info_submitted", data.noibu_checkout_shipping_info_submitted);
+        }
+        if (data.noibu_payment_info_submitted) {
+            track("payment_info_submitted", data.noibu_payment_info_submitted);
+        }
     });
 }
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Account.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Account.js
@@ -2,12 +2,14 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
 server.append("Show", function (req, res, next) {
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
-
+  safe(() => {
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Cart.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Cart.js
@@ -2,60 +2,68 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
-// var Logger = require('dw/system/Logger');
-// var log = Logger.getLogger('noibu');
-
 server.append("Show", function (req, res, next) {
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
+  safe(() => {
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
 
+    var cart = NoibuHelpers.getCartForTracking();
+    if (cart) {
+      res.setViewData({ noibu_cart_viewed: cart });
+    }
+  });
   next();
 });
 
 // Capture removed line item data before the base handler deletes it
 server.prepend("RemoveProductLineItem", function (req, res, next) {
-  if (req.querystring.pid && req.querystring.uuid) {
-    var BasketMgr = require("dw/order/BasketMgr");
-    var currentBasket = BasketMgr.getCurrentBasket();
-    if (currentBasket) {
-      var productLineItems = currentBasket.getAllProductLineItems(req.querystring.pid);
-      for (var i = 0; i < productLineItems.length; i++) {
-        var item = productLineItems[i];
-        if (item.UUID === req.querystring.uuid) {
-          var cartLine = NoibuHelpers.getCartLineForTracking(item);
-          if (cartLine) {
-            res.setViewData({ noibu_product_removed_from_cart: cartLine });
+  safe(() => {
+    if (req.querystring.pid && req.querystring.uuid) {
+      var BasketMgr = require("dw/order/BasketMgr");
+      var currentBasket = BasketMgr.getCurrentBasket();
+      if (currentBasket) {
+        var productLineItems = currentBasket.getAllProductLineItems(req.querystring.pid);
+        for (var i = 0; i < productLineItems.length; i++) {
+          var item = productLineItems[i];
+          if (item.UUID === req.querystring.uuid) {
+            var cartLine = NoibuHelpers.getCartLineForTracking(item);
+            if (cartLine) {
+              res.setViewData({ noibu_product_removed_from_cart: cartLine });
+            }
+            break;
           }
-          break;
         }
       }
     }
-  }
+  });
   next();
 });
 
 // Inject added line item data into the AddProduct JSON response
 server.append("AddProduct", function (req, res, next) {
-  var viewData = res.getViewData();
-  if (!viewData.error && viewData.pliUUID) {
-    var BasketMgr = require("dw/order/BasketMgr");
-    var currentBasket = BasketMgr.getCurrentBasket();
-    if (currentBasket) {
-      var productLineItems = currentBasket.getAllProductLineItems(req.form.pid);
-      for (var i = 0; i < productLineItems.length; i++) {
-        var item = productLineItems[i];
-        if (item.UUID === viewData.pliUUID) {
-          var cartLine = NoibuHelpers.getCartLineForTracking(item);
-          if (cartLine) {
-            res.setViewData({ noibu_product_added_to_cart: cartLine });
+  safe(() => {
+    var viewData = res.getViewData();
+    if (!viewData.error && viewData.pliUUID) {
+      var BasketMgr = require("dw/order/BasketMgr");
+      var currentBasket = BasketMgr.getCurrentBasket();
+      if (currentBasket) {
+        var productLineItems = currentBasket.getAllProductLineItems(req.form.pid);
+        for (var i = 0; i < productLineItems.length; i++) {
+          var item = productLineItems[i];
+          if (item.UUID === viewData.pliUUID) {
+            var cartLine = NoibuHelpers.getCartLineForTracking(item);
+            if (cartLine) {
+              res.setViewData({ noibu_product_added_to_cart: cartLine });
+            }
+            break;
           }
-          break;
         }
       }
     }
-  }
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Cart.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Cart.js
@@ -4,10 +4,58 @@ var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
 server.extend(module.superModule);
 
+// var Logger = require('dw/system/Logger');
+// var log = Logger.getLogger('noibu');
+
 server.append("Show", function (req, res, next) {
   res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
   res.setViewData(NoibuHelpers.getCart());
 
+  next();
+});
+
+// Capture removed line item data before the base handler deletes it
+server.prepend("RemoveProductLineItem", function (req, res, next) {
+  if (req.querystring.pid && req.querystring.uuid) {
+    var BasketMgr = require("dw/order/BasketMgr");
+    var currentBasket = BasketMgr.getCurrentBasket();
+    if (currentBasket) {
+      var productLineItems = currentBasket.getAllProductLineItems(req.querystring.pid);
+      for (var i = 0; i < productLineItems.length; i++) {
+        var item = productLineItems[i];
+        if (item.UUID === req.querystring.uuid) {
+          var cartLine = NoibuHelpers.getCartLineForTracking(item);
+          if (cartLine) {
+            res.setViewData({ noibu_product_removed_from_cart: cartLine });
+          }
+          break;
+        }
+      }
+    }
+  }
+  next();
+});
+
+// Inject added line item data into the AddProduct JSON response
+server.append("AddProduct", function (req, res, next) {
+  var viewData = res.getViewData();
+  if (!viewData.error && viewData.pliUUID) {
+    var BasketMgr = require("dw/order/BasketMgr");
+    var currentBasket = BasketMgr.getCurrentBasket();
+    if (currentBasket) {
+      var productLineItems = currentBasket.getAllProductLineItems(req.form.pid);
+      for (var i = 0; i < productLineItems.length; i++) {
+        var item = productLineItems[i];
+        if (item.UUID === viewData.pliUUID) {
+          var cartLine = NoibuHelpers.getCartLineForTracking(item);
+          if (cartLine) {
+            res.setViewData({ noibu_product_added_to_cart: cartLine });
+          }
+          break;
+        }
+      }
+    }
+  }
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Checkout.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Checkout.js
@@ -2,12 +2,14 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
 server.append("Begin", function (req, res, next) {
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
-
+  safe(() => {
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Checkout.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Checkout.js
@@ -9,6 +9,15 @@ server.append("Begin", function (req, res, next) {
   safe(() => {
     res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
     res.setViewData(NoibuHelpers.getCart());
+
+    var BasketMgr = require("dw/order/BasketMgr");
+    var basket = BasketMgr.getCurrentBasket();
+    if (basket) {
+      var checkoutStarted = NoibuHelpers.getCheckoutForTracking(basket, basket.UUID);
+      if (checkoutStarted) {
+        res.setViewData({ noibu_checkout_started: checkoutStarted });
+      }
+    }
   });
   next();
 });

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/CheckoutServices.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/CheckoutServices.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var server = require("server");
+var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
+server.extend(module.superModule);
+
+server.append("SubmitCustomer", function (req, res, next) {
+  safe(() => {
+    var viewData = res.getViewData();
+    if (!viewData.error) {
+      var BasketMgr = require("dw/order/BasketMgr");
+      var basket = BasketMgr.getCurrentBasket();
+      if (basket) {
+        var checkoutPayload = NoibuHelpers.getCheckoutForTracking(basket, basket.UUID);
+        if (checkoutPayload) {
+          res.setViewData({ noibu_checkout_contact_info_submitted: checkoutPayload });
+        }
+      }
+    }
+  });
+  next();
+});
+
+server.append("SubmitPayment", function (req, res, next) {
+  safe(() => {
+    var viewData = res.getViewData();
+    if (!viewData.error) {
+      var BasketMgr = require("dw/order/BasketMgr");
+      var basket = BasketMgr.getCurrentBasket();
+      if (basket) {
+        var checkoutPayload = NoibuHelpers.getCheckoutForTracking(basket, basket.UUID);
+        if (checkoutPayload) {
+          res.setViewData({ noibu_payment_info_submitted: checkoutPayload });
+        }
+      }
+    }
+  });
+  next();
+});
+
+module.exports = server.exports();

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/CheckoutShippingServices.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/CheckoutShippingServices.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var server = require("server");
+var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
+server.extend(module.superModule);
+
+// SubmitShipping sets both the shipping address and the shipping method,
+// so both checkout_address_info_submitted and checkout_shipping_info_submitted
+// are fired from this single endpoint.
+server.append("SubmitShipping", function (req, res, next) {
+  safe(() => {
+    var viewData = res.getViewData();
+    if (!viewData.error) {
+      var BasketMgr = require("dw/order/BasketMgr");
+      var basket = BasketMgr.getCurrentBasket();
+      if (basket) {
+        var checkoutPayload = NoibuHelpers.getCheckoutForTracking(basket, basket.UUID);
+        if (checkoutPayload) {
+          res.setViewData({
+            noibu_checkout_address_info_submitted: checkoutPayload,
+            noibu_checkout_shipping_info_submitted: checkoutPayload,
+          });
+        }
+      }
+    }
+  });
+  next();
+});
+
+module.exports = server.exports();

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Home.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Home.js
@@ -2,12 +2,14 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
 server.append("Show", function (req, res, next) {
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
-
+  safe(() => {
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Order.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Order.js
@@ -13,6 +13,11 @@ server.append("Confirm", function (req, res, next) {
     res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
     res.setViewData(NoibuHelpers.getCart());
     res.setViewData(NoibuHelpers.getOrder(orderId, orderToken));
+
+    var checkoutCompleted = NoibuHelpers.getOrderCheckoutForTracking(orderId, orderToken);
+    if (checkoutCompleted) {
+      res.setViewData({ noibu_checkout_completed: checkoutCompleted });
+    }
   });
   next();
 });

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Order.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Order.js
@@ -2,17 +2,18 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
 server.append("Confirm", function (req, res, next) {
-  // Check both query parameters (GET) and form data (POST)
-  var orderId = req.form.orderID || req.querystring.orderID;
-  var orderToken = req.form.orderToken || req.querystring.orderToken;
-
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
-  res.setViewData(NoibuHelpers.getOrder(orderId, orderToken));
-
+  safe(() => {
+    // Check both query parameters (GET) and form data (POST)
+    var orderId = req.form.orderID || req.querystring.orderID;
+    var orderToken = req.form.orderToken || req.querystring.orderToken;
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
+    res.setViewData(NoibuHelpers.getOrder(orderId, orderToken));
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Product.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Product.js
@@ -2,12 +2,19 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
 server.append("Show", function (req, res, next) {
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
+  safe(() => {
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
 
+    var product = NoibuHelpers.getProductForTracking(req.querystring.pid);
+    if (product) {
+      res.setViewData({ noibu_product_viewed: product });
+    }
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Search.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Search.js
@@ -10,11 +10,16 @@ server.append("Show", function (req, res, next) {
     res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
     res.setViewData(NoibuHelpers.getCart());
 
+    var productSearch = res.getViewData().productSearch;
     if (req.querystring.cgid) {
-      var productSearch = res.getViewData().productSearch;
       var collection = NoibuHelpers.getCollectionForTracking(productSearch);
       if (collection) {
         res.setViewData({ noibu_collection_viewed: collection });
+      }
+    } else if (req.querystring.q) {
+      var search = NoibuHelpers.getSearchForTracking(productSearch, req.querystring.q);
+      if (search) {
+        res.setViewData({ noibu_search_submitted: search });
       }
     }
   });

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Search.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/controllers/Search.js
@@ -2,12 +2,22 @@
 
 var server = require("server");
 var NoibuHelpers = require("*/cartridge/scripts/helpers/NoibuHelpers");
+var safe = require("*/cartridge/scripts/helpers/safe");
 server.extend(module.superModule);
 
 server.append("Show", function (req, res, next) {
-  res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
-  res.setViewData(NoibuHelpers.getCart());
+  safe(() => {
+    res.setViewData(NoibuHelpers.getCustomer(req.currentCustomer));
+    res.setViewData(NoibuHelpers.getCart());
 
+    if (req.querystring.cgid) {
+      var productSearch = res.getViewData().productSearch;
+      var collection = NoibuHelpers.getCollectionForTracking(productSearch);
+      if (collection) {
+        res.setViewData({ noibu_collection_viewed: collection });
+      }
+    }
+  });
   next();
 });
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
@@ -72,4 +72,58 @@ module.exports = {
       noibuOrder: noibuOrder,
     };
   },
+
+  getCartLineForTracking: function (pli) {
+    var URLUtils = require("dw/web/URLUtils");
+
+    var product = pli.product;
+    if (!product) return null;
+
+    var masterProduct = product.isVariant()
+      ? product.variationModel.master
+      : product;
+
+    var images = product.getImages("small");
+    var image = images && images.length > 0 ? images[0] : null;
+
+    var unitPrice = pli.basePrice;
+    var totalPrice = pli.adjustedPrice;
+
+    return {
+      cartLine: {
+        cost: {
+          totalAmount: {
+            amount: totalPrice ? totalPrice.value : 0,
+            currencyCode: totalPrice ? totalPrice.currencyCode : "",
+          },
+        },
+        merchandise: {
+          id: pli.productID,
+          title: pli.productName,
+          sku: product.UPC || pli.productID,
+          price: {
+            amount: unitPrice ? unitPrice.value : 0,
+            currencyCode: unitPrice ? unitPrice.currencyCode : "",
+          },
+          image: image
+            ? {
+                src: image.absURL ? image.absURL.toString() : "",
+                alt: image.alt || "",
+              }
+            : null,
+          product: {
+            id: masterProduct.ID,
+            title: masterProduct.name,
+            type:
+              masterProduct.primaryCategory
+                ? masterProduct.primaryCategory.displayName
+                : "",
+            url: URLUtils.abs("Product-Show", "pid", masterProduct.ID).toString(),
+            vendor: masterProduct.brand || "",
+          },
+        },
+        quantity: pli.quantityValue,
+      },
+    };
+  },
 };

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
@@ -157,14 +157,6 @@ module.exports = {
     };
   },
 
-  /**
-   * Builds a Shopify-shaped checkout payload from a SFCC LineItemCtnr
-   * (works for both Basket and Order since they share the same interface).
-   *
-   * @param {dw.order.LineItemCtnr} lineItemCtnr
-   * @param {string} token - basket UUID or order token
-   * @returns {Object|null}
-   */
   getCheckoutForTracking: function (lineItemCtnr, token) {
     var shipment = lineItemCtnr.defaultShipment;
 
@@ -233,14 +225,6 @@ module.exports = {
     };
   },
 
-  /**
-   * Builds a Shopify-shaped checkout_completed payload from a placed order.
-   * Extends getCheckoutForTracking with order ID and transaction data.
-   *
-   * @param {string} orderId
-   * @param {string} orderToken
-   * @returns {Object|null}
-   */
   getOrderCheckoutForTracking: function (orderId, orderToken) {
     if (!orderId) return null;
 
@@ -330,13 +314,6 @@ module.exports = {
   },
 };
 
-/**
- * Maps a SFCC OrderAddress to a Shopify mailingAddress shape.
- * Shared by getCheckoutForTracking and getOrderCheckoutForTracking.
- *
- * @param {dw.order.OrderAddress} address
- * @returns {Object|null}
- */
 function getAddressForTracking(address) {
   if (!address) return null;
   return {
@@ -353,13 +330,6 @@ function getAddressForTracking(address) {
   };
 }
 
-/**
- * Builds a Shopify-shaped productVariant payload from a raw SFCC product.
- * Shared by getProductViewedForTracking and getCollectionViewedForTracking.
- *
- * @param {dw.catalog.Product} product
- * @returns {Object} productVariant payload
- */
 function getProductVariantForTracking(product) {
   var URLUtils = require("dw/web/URLUtils");
 

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
@@ -104,6 +104,28 @@ module.exports = {
     };
   },
 
+  getSearchForTracking: function (productSearch, query) {
+    if (!query) return null;
+
+    var ProductMgr = require("dw/catalog/ProductMgr");
+    var productVariants = [];
+    var productIds = productSearch ? productSearch.productIds : [];
+
+    for (var i = 0; i < productIds.length; i++) {
+      var product = ProductMgr.getProduct(productIds[i].productID);
+      if (product) {
+        productVariants.push(getProductVariantForTracking(product));
+      }
+    }
+
+    return {
+      searchResult: {
+        query: query,
+        productVariants: productVariants,
+      },
+    };
+  },
+
   getCartForTracking: function () {
     var BasketMgr = require("dw/order/BasketMgr");
     var basket = BasketMgr.getCurrentBasket();

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
@@ -157,6 +157,124 @@ module.exports = {
     };
   },
 
+  /**
+   * Builds a Shopify-shaped checkout payload from a SFCC LineItemCtnr
+   * (works for both Basket and Order since they share the same interface).
+   *
+   * @param {dw.order.LineItemCtnr} lineItemCtnr
+   * @param {string} token - basket UUID or order token
+   * @returns {Object|null}
+   */
+  getCheckoutForTracking: function (lineItemCtnr, token) {
+    var shipment = lineItemCtnr.defaultShipment;
+
+    var lineItems = [];
+    var productLineItems = lineItemCtnr.productLineItems;
+    for (var i = 0; i < productLineItems.length; i++) {
+      var cartLine = module.exports.getCartLineForTracking(productLineItems[i]);
+      if (!cartLine) continue;
+      lineItems.push({
+        quantity: cartLine.cartLine.quantity,
+        finalLinePrice: cartLine.cartLine.cost.totalAmount,
+        merchandise: cartLine.cartLine.merchandise,
+      });
+    }
+
+    var discountApplications = [];
+    var priceAdjustments = lineItemCtnr.getPriceAdjustments();
+    for (var j = 0; j < priceAdjustments.length; j++) {
+      var pa = priceAdjustments[j];
+      discountApplications.push({
+        title: pa.promotionID || "",
+        value: {
+          amount: pa.price ? Math.abs(pa.price.value) : 0,
+          currencyCode: pa.price ? pa.price.currencyCode : "",
+        },
+      });
+    }
+
+    var subtotal = lineItemCtnr.adjustedMerchandizeTotalPrice;
+    var totalGross = lineItemCtnr.totalGrossPrice;
+    var totalTax = lineItemCtnr.totalTax;
+    var shippingTotal = lineItemCtnr.shippingTotalPrice;
+    var shippingMethod = shipment ? shipment.shippingMethod : null;
+
+    return {
+      checkout: {
+        token: token || "",
+        email: lineItemCtnr.customerEmail || "",
+        phone: lineItemCtnr.billingAddress ? lineItemCtnr.billingAddress.phone || "" : "",
+        currencyCode: lineItemCtnr.currencyCode || "",
+        lineItems: lineItems,
+        billingAddress: getAddressForTracking(lineItemCtnr.billingAddress),
+        shippingAddress: getAddressForTracking(shipment ? shipment.shippingAddress : null),
+        shippingLine: shippingMethod
+          ? {
+              price: {
+                amount: shippingTotal ? shippingTotal.value : 0,
+                currencyCode: shippingTotal ? shippingTotal.currencyCode : "",
+              },
+            }
+          : null,
+        subtotalPrice: {
+          amount: subtotal ? subtotal.value : 0,
+          currencyCode: subtotal ? subtotal.currencyCode : "",
+        },
+        totalPrice: {
+          amount: totalGross ? totalGross.value : 0,
+          currencyCode: totalGross ? totalGross.currencyCode : "",
+        },
+        totalTax: {
+          amount: totalTax ? totalTax.value : 0,
+          currencyCode: totalTax ? totalTax.currencyCode : "",
+        },
+        discountApplications: discountApplications,
+      },
+    };
+  },
+
+  /**
+   * Builds a Shopify-shaped checkout_completed payload from a placed order.
+   * Extends getCheckoutForTracking with order ID and transaction data.
+   *
+   * @param {string} orderId
+   * @param {string} orderToken
+   * @returns {Object|null}
+   */
+  getOrderCheckoutForTracking: function (orderId, orderToken) {
+    if (!orderId) return null;
+
+    var OrderMgr = require("dw/order/OrderMgr");
+    var order = OrderMgr.getOrder(orderId, orderToken);
+    if (!order) return null;
+
+    var result = module.exports.getCheckoutForTracking(order, orderToken);
+    if (!result) return null;
+
+    result.checkout.order = {
+      id: order.orderNo,
+      customer: { id: order.customerNo || "" },
+    };
+
+    var transactions = [];
+    var paymentInstruments = order.getPaymentInstruments();
+    for (var i = 0; i < paymentInstruments.length; i++) {
+      var pi = paymentInstruments[i];
+      var txn = pi.paymentTransaction;
+      transactions.push({
+        amount: {
+          amount: txn ? txn.amount.value : 0,
+          currencyCode: txn ? txn.amount.currencyCode : "",
+        },
+        gateway: pi.paymentMethod || "",
+        paymentMethod: { type: pi.paymentMethod || "" },
+      });
+    }
+    result.checkout.transactions = transactions;
+
+    return result;
+  },
+
   getCartLineForTracking: function (pli) {
     var URLUtils = require("dw/web/URLUtils");
 
@@ -211,6 +329,29 @@ module.exports = {
     };
   },
 };
+
+/**
+ * Maps a SFCC OrderAddress to a Shopify mailingAddress shape.
+ * Shared by getCheckoutForTracking and getOrderCheckoutForTracking.
+ *
+ * @param {dw.order.OrderAddress} address
+ * @returns {Object|null}
+ */
+function getAddressForTracking(address) {
+  if (!address) return null;
+  return {
+    firstName: address.firstName || "",
+    lastName: address.lastName || "",
+    address1: address.address1 || "",
+    address2: address.address2 || "",
+    city: address.city || "",
+    province: address.stateCode || "",
+    provinceCode: address.stateCode || "",
+    countryCode: address.countryCode ? address.countryCode.value || String(address.countryCode) : "",
+    zip: address.postalCode || "",
+    phone: address.phone || "",
+  };
+}
 
 /**
  * Builds a Shopify-shaped productVariant payload from a raw SFCC product.

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
@@ -73,6 +73,68 @@ module.exports = {
     };
   },
 
+  getProductForTracking: function (pid) {
+    var ProductMgr = require("dw/catalog/ProductMgr");
+    var product = ProductMgr.getProduct(pid);
+    if (!product) return null;
+
+    return { productVariant: getProductVariantForTracking(product) };
+  },
+
+  getCollectionForTracking: function (productSearch) {
+    if (!productSearch || !productSearch.category) return null;
+
+    var ProductMgr = require("dw/catalog/ProductMgr");
+    var productVariants = [];
+    var productIds = productSearch.productIds;
+
+    for (var i = 0; i < productIds.length; i++) {
+      var product = ProductMgr.getProduct(productIds[i].productID);
+      if (product) {
+        productVariants.push(getProductVariantForTracking(product));
+      }
+    }
+
+    return {
+      collection: {
+        id: productSearch.category.id,
+        title: productSearch.category.name,
+        productVariants: productVariants,
+      },
+    };
+  },
+
+  getCartForTracking: function () {
+    var BasketMgr = require("dw/order/BasketMgr");
+    var basket = BasketMgr.getCurrentBasket();
+    if (!basket) return null;
+
+    var lines = [];
+    var productLineItems = basket.productLineItems;
+    for (var i = 0; i < productLineItems.length; i++) {
+      var cartLine = module.exports.getCartLineForTracking(productLineItems[i]);
+      if (cartLine) {
+        lines.push(cartLine.cartLine);
+      }
+    }
+
+    var total = basket.adjustedMerchandizeTotalPrice;
+
+    return {
+      cart: {
+        id: basket.UUID,
+        totalQuantity: basket.productQuantityTotal,
+        cost: {
+          totalAmount: {
+            amount: total ? total.value : 0,
+            currencyCode: total ? total.currencyCode : "",
+          },
+        },
+        lines: lines,
+      },
+    };
+  },
+
   getCartLineForTracking: function (pli) {
     var URLUtils = require("dw/web/URLUtils");
 
@@ -127,3 +189,48 @@ module.exports = {
     };
   },
 };
+
+/**
+ * Builds a Shopify-shaped productVariant payload from a raw SFCC product.
+ * Shared by getProductViewedForTracking and getCollectionViewedForTracking.
+ *
+ * @param {dw.catalog.Product} product
+ * @returns {Object} productVariant payload
+ */
+function getProductVariantForTracking(product) {
+  var URLUtils = require("dw/web/URLUtils");
+
+  var masterProduct = product.isVariant()
+    ? product.variationModel.master
+    : product;
+
+  var images = product.getImages("small");
+  var image = images && images.length > 0 ? images[0] : null;
+  var priceModel = product.getPriceModel();
+  var price = priceModel.getPrice();
+  if (!price.available) {
+    price = priceModel.getMinPrice();
+  }
+
+  return {
+    id: product.ID,
+    title: product.name,
+    sku: product.UPC || product.ID,
+    price: {
+      amount: price && price.available ? price.value : 0,
+      currencyCode: price && price.available ? price.currencyCode : "",
+    },
+    image: image
+      ? { src: image.absURL ? image.absURL.toString() : "" }
+      : null,
+    product: {
+      id: masterProduct.ID,
+      title: masterProduct.name,
+      type: masterProduct.primaryCategory
+        ? masterProduct.primaryCategory.displayName
+        : "",
+      vendor: masterProduct.brand || "",
+      url: URLUtils.abs("Product-Show", "pid", masterProduct.ID).toString(),
+    },
+  };
+}

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/safe.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/safe.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var Logger = require("dw/system/Logger");
+var log = Logger.getLogger("noibu", "noibu");
+
+module.exports = function safe(callback) {
+    try {
+        callback();
+    } catch (error) {
+        log.error("noibu error: {0}", error);
+    }
+};

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
@@ -30,7 +30,7 @@
             window.addEventListener("noibuSDKReady", addNoibuAttributes);
         }
     </script>
-    <isif condition="${pdict.noibu_cart_viewed || pdict.noibu_product_viewed || pdict.noibu_collection_viewed}">
+    <isif condition="${pdict.noibu_cart_viewed || pdict.noibu_product_viewed || pdict.noibu_collection_viewed || pdict.noibu_search_submitted}">
     <script>
         (function () {
             var events = [];
@@ -42,6 +42,9 @@
             </isif>
             <isif condition="${pdict.noibu_collection_viewed}">
             events.push(["collection_viewed", <isprint value="${JSON.stringify(pdict.noibu_collection_viewed)}" encoding="off" />]);
+            </isif>
+            <isif condition="${pdict.noibu_search_submitted}">
+            events.push(["search_submitted", <isprint value="${JSON.stringify(pdict.noibu_search_submitted)}" encoding="off" />]);
             </isif>
             function trackAll() {
                 events.forEach(([name, payload]) => {

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
@@ -52,16 +52,15 @@
             <isif condition="${pdict.noibu_search_submitted}">
             events.push(["search_submitted", <isprint value="${JSON.stringify(pdict.noibu_search_submitted)}" encoding="off" />]);
             </isif>
-            function trackAll() {
+            function track() {
                 events.forEach(([name, payload]) => {
                     const result = NOIBUJS.track(name, payload);
-                    console.log('NOIBUJS.track:', name, result, payload);
                 });
             }
             if (window.NOIBUJS) {
-                trackAll();
+                track();
             } else {
-                window.addEventListener("noibuSDKReady", trackAll);
+                window.addEventListener("noibuSDKReady", track);
             }
         })();
     </script>

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
@@ -30,4 +30,31 @@
             window.addEventListener("noibuSDKReady", addNoibuAttributes);
         }
     </script>
+    <isif condition="${pdict.noibu_cart_viewed || pdict.noibu_product_viewed || pdict.noibu_collection_viewed}">
+    <script>
+        (function () {
+            var events = [];
+            <isif condition="${pdict.noibu_cart_viewed}">
+            events.push(["cart_viewed", <isprint value="${JSON.stringify(pdict.noibu_cart_viewed)}" encoding="off" />]);
+            </isif>
+            <isif condition="${pdict.noibu_product_viewed}">
+            events.push(["product_viewed", <isprint value="${JSON.stringify(pdict.noibu_product_viewed)}" encoding="off" />]);
+            </isif>
+            <isif condition="${pdict.noibu_collection_viewed}">
+            events.push(["collection_viewed", <isprint value="${JSON.stringify(pdict.noibu_collection_viewed)}" encoding="off" />]);
+            </isif>
+            function trackAll() {
+                events.forEach(([name, payload]) => {
+                    const result = NOIBUJS.track(name, payload);
+                    console.log('NOIBUJS.track:', name, result, payload);
+                });
+            }
+            if (window.NOIBUJS) {
+                trackAll();
+            } else {
+                window.addEventListener("noibuSDKReady", trackAll);
+            }
+        })();
+    </script>
+    </isif>
 </isif>

--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/templates/default/noibu/include/noibuFooterInclude.isml
@@ -30,10 +30,16 @@
             window.addEventListener("noibuSDKReady", addNoibuAttributes);
         }
     </script>
-    <isif condition="${pdict.noibu_cart_viewed || pdict.noibu_product_viewed || pdict.noibu_collection_viewed || pdict.noibu_search_submitted}">
+    <isif condition="${pdict.noibu_checkout_started || pdict.noibu_checkout_completed || pdict.noibu_cart_viewed || pdict.noibu_product_viewed || pdict.noibu_collection_viewed || pdict.noibu_search_submitted}">
     <script>
         (function () {
             var events = [];
+            <isif condition="${pdict.noibu_checkout_started}">
+            events.push(["checkout_started", <isprint value="${JSON.stringify(pdict.noibu_checkout_started)}" encoding="off" />]);
+            </isif>
+            <isif condition="${pdict.noibu_checkout_completed}">
+            events.push(["checkout_completed", <isprint value="${JSON.stringify(pdict.noibu_checkout_completed)}" encoding="off" />]);
+            </isif>
             <isif condition="${pdict.noibu_cart_viewed}">
             events.push(["cart_viewed", <isprint value="${JSON.stringify(pdict.noibu_cart_viewed)}" encoding="off" />]);
             </isif>


### PR DESCRIPTION
## Noibu SDK Ecommerce Event Tracking

Implements Noibu SDK ecommerce event tracking across the SFRA storefront following [Shopify's Web Pixels API](https://shopify.dev/docs/api/web-pixels-api) payload format.

### Architecture

**Page cache safety** is the core design constraint. Shopper-specific data can never be injected into `pdict` on cached page responses. The solution splits responsibilities:

- Controllers set only `noibu_page_type` + `noibu_page_id` in `pdict` (safe to cache)
- A dedicated `Noibu-GetAttributes` endpoint (explicitly uncached) builds and returns all shopper-specific payloads, including ecomm event data, customer attributes, and session ID

**All client-side logic** lives in `noibu.js` as `window.noibuSFCC = { init }`. On each page load, `noibuFooterInclude.isml` passes a minimal server-rendered config to `init()`, which fetches from `Noibu-GetAttributes` and fires page-view events.   
A single `$.ajaxComplete` listener handles all AJAX-response events.