### PR TITLE
SFCC checkout completed event missing product titles

### DIFF
--- a/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
+++ b/link_noibu/cartridges/int_noibu_sfra_changes/cartridge/scripts/helpers/NoibuHelpers.js
@@ -166,9 +166,11 @@ module.exports = {
       var cartLine = module.exports.getCartLineForTracking(productLineItems[i]);
       if (!cartLine) continue;
       lineItems.push({
+        id: cartLine.cartLine.merchandise.product.id,
         quantity: cartLine.cartLine.quantity,
         finalLinePrice: cartLine.cartLine.cost.totalAmount,
-        merchandise: cartLine.cartLine.merchandise,
+        title: cartLine.cartLine.merchandise.product.title,
+        variant: cartLine.cartLine.merchandise,
       });
     }
 


### PR DESCRIPTION
The SFCC cartridge's checkout events do not include product titles, which causes the products section in order data to look incorrect.